### PR TITLE
Fix RPM package build when running as non-root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ services:
   - docker
 
 script:
+  # at least run a syntax check for the Travis script
+  - bash -n yast-travis-ruby
   - docker build -t yast-test-image .

--- a/yast-travis-ruby
+++ b/yast-travis-ruby
@@ -34,7 +34,17 @@ COVERAGE=1 CI=1 rake test:unit
 
 # build the binary package locally, use plain "rpmbuild" to make it simple
 rake tarball > /dev/null 2>&1
-cp package/* /usr/src/packages/SOURCES/
+
+# support RPM building for both root and non-root
+if [ "$UID" == "0" ]; then
+  PKG_DIR=/usr/src/packages
+else
+  PKG_DIR=~/rpmbuild
+fi
+
+mkdir -p $PKG_DIR/SOURCES/
+cp package/* $PKG_DIR/SOURCES/
+
 # Build the binary package, skip the %check section,
 # the tests have been already executed outside RPM build.
 # If it fails try to build the package with ignored deps, maybe it can work anyway...
@@ -43,7 +53,7 @@ rpmbuild -bb --nocheck package/*.spec || rpmbuild -bb --nocheck --nodeps package
 
 # test the %pre/%post scripts by installing/updating/removing the built packages
 # ignore the dependencies to make the test easier, as a smoke test it's good enough
-rpm -iv --force --nodeps /usr/src/packages/RPMS/**/*.rpm
-rpm -Uv --force --nodeps /usr/src/packages/RPMS/**/*.rpm
+rpm -iv --force --nodeps $PKG_DIR/RPMS/*/*.rpm
+rpm -Uv --force --nodeps $PKG_DIR/RPMS/*/*.rpm
 # get the plain package names and remove all packages at once
-rpm -ev --nodeps `rpm -q --qf '%{NAME} ' -p /usr/src/packages/RPMS/**/*.rpm`
+rpm -ev --nodeps `rpm -q --qf '%{NAME} ' -p $PKG_DIR/RPMS/*/*.rpm`


### PR DESCRIPTION
- The non-root build is needed as a workaround for an yast2-fonts bug in the tests (see https://github.com/yast/yast-fonts/pull/25).
- Additionally check the script syntax at Travis.
- Tested with the `yast2-font` package locally.