### PR TITLE
Run the osc source validator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
   'rubygem(suse-connect)' \
   'rubygem(yard)' \
   'rubygem(yast-rake)' \
+  obs-service-source_validator \
   yast2 \
   yast2-add-on \
   yast2-bootloader \

--- a/yast-travis-ruby
+++ b/yast-travis-ruby
@@ -35,6 +35,11 @@ COVERAGE=1 CI=1 rake test:unit
 # build the binary package locally, use plain "rpmbuild" to make it simple
 rake tarball > /dev/null 2>&1
 
+if [ -d package ]; then
+  # run the osc source validator to check the .spec and .changes locally
+  (cd package && /usr/lib/obs/service/source_validator)
+fi
+
 # support RPM building for both root and non-root
 if [ "$UID" == "0" ]; then
   PKG_DIR=/usr/src/packages


### PR DESCRIPTION
Run the osc source validator at Travis to check the `*.spec` and `*.changes` locally.

I found out that in [this PR](https://github.com/yast/yast-packager/pull/225) build succeeded at Travis but [failed in Jenkins](https://ci.opensuse.org/job/yast-packager-github-push/231//console). It turned out that the Jenkins failure was caused by a wrong changelog sequence (dates not in ascending order) which is not tested at Travis.

To make the Travis builds more close to the OBS builds we should run this additional check at Travis as well.

**Note:** I'll add this check also to the other Docker images (scripts) we use at Travis.