### PR TITLE
Add SLE 12 SP2 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM opensuse:tumbleweed
-RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
+FROM opensuse:42.2
+RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ yast_sle_12_sp2
 
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run


### PR DESCRIPTION
I'm not sure if using a different branch is the right approach. Perhaps we could just have a different Dockerfile for each distribution, so you can do:

```
sudo docker build -t yast-sle-12-sp2-image -f Dockerfile-sle-12-sp2 .
```

Opinions?