### PR TITLE
Sync the packages with Factory first

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,6 +1,9 @@
 FROM opensuse:tumbleweed
 RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
+# "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed)
+RUN zypper --gpg-auto-import-keys --non-interactive dup --no-recommends
+
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -2,7 +2,8 @@ FROM opensuse:tumbleweed
 RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
 # "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed)
-RUN zypper --gpg-auto-import-keys --non-interactive dup --no-recommends
+RUN zypper --gpg-auto-import-keys --non-interactive dup --no-recommends \
+  && zypper clean -a
 
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run


### PR DESCRIPTION
Fixes the downgrade issue: https://hub.docker.com/r/yastdevel/storage-ng/builds/brsaboj3hhb9ccndbesmcu3/

This rather looks like a workaround but I guess we can keep it even when the Docker image is fixed, this will ensure we have up to date image even if the official Tumbleweed Docker image is not updated for few days.