### PR TITLE
Fixes for building patterns-yast package

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -61,7 +61,7 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   yast2-security \
   yast2-services-manager \
   yast2-slp \
-  yast2-storage \
+  yast2-storage-ng \
   yast2-testsuite \
   yast2-transfer \
   yast2-update \

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -37,6 +37,7 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   "rubygem($RUBY_VERSION:yard)" \
   "rubygem($RUBY_VERSION:yast-rake)" \
   obs-service-source_validator \
+  patterns-rpm-macros \
   yast2 \
   yast2-add-on \
   yast2-bootloader \

--- a/yast-travis-ruby
+++ b/yast-travis-ruby
@@ -17,7 +17,10 @@ if [ -e .spell.yml ]; then
   rake check:spelling
 fi
 
-yardoc
+# run yardoc when there is at least one Ruby file
+if [ ! -z `find . -name '*.rb' -print -quit` ]; then
+  yardoc
+fi
 
 # autotools based package
 if [ -e Makefile.cvs ]; then


### PR DESCRIPTION
We use this Ruby image also for building some non-Ruby packages, for `patterns-yast` we need some enhancements:

- Run `yardoc` only when there is at least one Ruby file (to avoid creating bogus `doc/` and `.yardoc/` directories)
- Include the RPM macros needed for building (it's small, ~10KB so it's OK to add it globally)
- Switched to `yast2-storage-ng`
