### PR TITLE
Explicitly add the "build" package

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -36,6 +36,7 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   "rubygem($RUBY_VERSION:suse-connect)" \
   "rubygem($RUBY_VERSION:yard)" \
   "rubygem($RUBY_VERSION:yast-rake)" \
+  build \
   obs-service-source_validator \
   patterns-rpm-macros \
   yast2 \


### PR DESCRIPTION
It should be required by "obs-service-source_validator", but for some reason the dependency is missing.

Fixes https://travis-ci.org/yast/yast-packager/builds/267202094