### PR TITLE
Travis fix - remove the &STDERR file created by YaST

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -76,5 +76,7 @@ ENV LC_ALL=en_US.UTF-8
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# just some smoke tests, make sure rake and YaST work properly
-RUN rake -r yast/rake -V && TERM=xterm yast2 proxy summary && rm -rf /var/log/YaST2/y2log
+# just some smoke tests, make sure rake and YaST work properly,
+# ensure there is no leftover in the working directory
+RUN rake -r yast/rake -V && TERM=xterm yast2 proxy summary && \
+  rm -rf /var/log/YaST2/y2log && rm -rf /usr/src/app/*


### PR DESCRIPTION
- Hotfix to remove the `&STDERR` file created by `yast2 proxy summary` call
- Interestengly that file is created only when terminal is not present, if a terminal is present the file is not created
- Seems to be related to upgrade to perl-5.26.1 in Tumbleweed