### PR TITLE
Improved security

### DIFF
--- a/Dockerfile.caasp-1_0
+++ b/Dockerfile.caasp-1_0
@@ -3,25 +3,28 @@
 # (which is used as the base for CaaSP) for running the YaST tests.
 FROM opensuse:42.2
 
+# we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# and curl for downloading/installing the GPG key
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
+# why we need "zypper clean -a" at the end
+RUN zypper --non-interactive in --no-recommends curl ruby && zypper clean -a
+
+# import the YaST OBS GPG key
+RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
+
 # Set a higher priority for the yast_sle_12_sp2 repo to prefer the packages from
 # this repo even if they have a lower version than the original 42.2 packages.
-RUN zypper ar -f -p95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
+RUN zypper ar -f -p95 https://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
   yast_sle_12_sp2
 
 # Set the highest priority for the yast_caasp_1.0 repo to override the
 # yast_sle_12_sp2 and the original 42.2 packages.
-RUN zypper ar -f -p30 http://download.opensuse.org/repositories/YaST:/CASP:/1.0/SLE_12_SP2/ \
+RUN zypper ar -f -p30 https://download.opensuse.org/repositories/YaST:/CASP:/1.0/SLE_12_SP2/ \
   yast_caasp_1.0
 
-# we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
-# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
-# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
-# why we need "zypper clean -a" at the end
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby && zypper clean -a
-
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \
   git \

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,19 +1,22 @@
 FROM opensuse:tumbleweed
-RUN zypper ar -f http://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
-# "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed)
-RUN zypper --gpg-auto-import-keys --non-interactive dup --no-recommends \
-  && zypper clean -a
-
+# "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed),
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
 # why we need "zypper clean -a" at the end
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby && zypper clean -a
+RUN zypper --non-interactive dup --no-recommends && \
+  zypper --non-interactive in --no-recommends curl ruby && \
+  zypper clean -a
+
+# import the YaST OBS GPG key
+RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
+
+RUN zypper ar -f https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \
   git \

--- a/Dockerfile.sle12-sp2
+++ b/Dockerfile.sle12-sp2
@@ -4,20 +4,23 @@
 # for running the YaST tests.
 FROM opensuse:42.2
 
-# Set a higher priority for the yast_sle_12_sp2 repo to prefer the packages from
-# this repo even if they have a lower version than the original 42.2 packages.
-RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
-  yast_sle12_sp2
-
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
 # why we need "zypper clean -a" at the end
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby && zypper clean -a
+RUN zypper --non-interactive in --no-recommends curl ruby && zypper clean -a
+
+# import the YaST OBS GPG key
+RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
+
+# Set a higher priority for the yast_sle_12_sp2 repo to prefer the packages from
+# this repo even if they have a lower version than the original 42.2 packages.
+RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
+yast_sle12_sp2
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \
   git \

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -2,25 +2,25 @@
 # because of some licensing issues, use openSUSE-42.3 as a replacement.
 # It shares the same core packages and should be close enough to SLE12-SP3
 # for running the YaST tests.
-# FIXME: for now use our own 42.3 image, the officiall image has not been
-# published yet
-# TODO: FROM opensuse:42.3
-FROM yastdevel/opensuse-42.3
-
-# Set a higher priority for the yast_sle_12_sp3 repo to prefer the packages from
-# this repo even if they have a lower version than the original 42.2 packages.
-RUN zypper ar -f -p 95 http://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/openSUSE_Leap_42.3/ \
-  yast_sle12_sp3
+FROM opensuse:42.3
 
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
+# and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache
 # why we need "zypper clean -a" at the end
-RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  ruby && zypper clean -a
+RUN zypper --non-interactive in --no-recommends curl ruby && zypper clean -a
+
+# import the YaST OBS GPG key
+RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
+
+# Set a higher priority for the yast_sle_12_sp3 repo to prefer the packages from
+# this repo even if they have a lower version than the original 42.2 packages.
+RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/openSUSE_Leap_42.3/ \
+  yast_sle12_sp3
 
 RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
-  zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
+  zypper --non-interactive in --no-recommends \
   aspell-en \
   fdupes \
   git \

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -15,7 +15,7 @@ RUN zypper --non-interactive in --no-recommends curl ruby && zypper clean -a
 RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
 
 # Set a higher priority for the yast_sle_12_sp3 repo to prefer the packages from
-# this repo even if they have a lower version than the original 42.2 packages.
+# this repo even if they have a lower version than the original 42.3 packages.
 RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-12:/SP3/openSUSE_Leap_42.3/ \
   yast_sle12_sp3
 


### PR DESCRIPTION
The improved security is not critical as we use the image primarily at Travis just for running the tests. But if someone would like to use it as a development environment it would be a good idea to make it more trustworthy. Especially the HTTP repo with the `--gpg-auto-import-keys` zyppper option is dangerous...

- Do not automatically import any "random" GPG key (via `--gpg-auto-import-keys`  zypper option),  instead import the specific YaST GPG key downloaded from OBS
- Use HTTPS for the repository URLs (instead of plain HTTP)
- Switched to the official openSUSE-42.3 image

