### PR TITLE
Replace opensuse:tumbleweed with opensuse/tumbleweed

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,4 +1,4 @@
-FROM opensuse:tumbleweed
+FROM opensuse/tumbleweed
 
 # "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed),
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro


### PR DESCRIPTION
We should not merge this change yet. Additionally, I wonder if we should update `opensuse:42.3` to `opensuse/42.3`.

See https://lists.opensuse.org/opensuse-factory/2018-03/msg00389.html