### PR TITLE
Remove the &STDERR file

### DIFF
--- a/Dockerfile.sle15
+++ b/Dockerfile.sle15
@@ -82,5 +82,7 @@ ENV LC_ALL=en_US.UTF-8
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# just some smoke tests, make sure rake and YaST work properly
-RUN rake -r yast/rake -V && TERM=xterm yast2 proxy summary && rm -rf /var/log/YaST2/y2log
+# just some smoke tests, make sure rake and YaST work properly,
+# ensure there is no leftover in the working directory
+RUN rake -r yast/rake -V && TERM=xterm yast2 proxy summary && \
+  rm -rf /var/log/YaST2/y2log && rm -rf /usr/src/app/*


### PR DESCRIPTION
- Similar fix to https://github.com/yast/docker-yast-ruby/commit/fa0f043173513ee0db738427787ffe5845bde7c4
- There is a bug in the Perl Term library, already a [patch](http://code.activestate.com/lists/perl5-porters/237656/) provided, unfortunately [still not merged](https://rt.perl.org/Public/Bug/Display.html?id=132008) :worried: 