### PR TITLE
Image cleanup, remove useless files

### DIFF
--- a/Dockerfile.caasp-1_0
+++ b/Dockerfile.caasp-1_0
@@ -3,6 +3,9 @@
 # (which is used as the base for CaaSP) for running the YaST tests.
 FROM opensuse:42.2
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
@@ -77,7 +80,9 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   yast2-users \
   yast2-xml \
   yast2-ycp-ui-bindings \
-  && zypper clean -a
+  && zypper clean -a \
+  && rm -rf /usr/lib*/ruby/gems/*/cache/ \
+  && rm -rf /usr/share/doc/
 
 COPY yast-travis-ruby /usr/local/bin/
 ENV LC_ALL=en_US.UTF-8

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -1,5 +1,8 @@
 FROM opensuse/tumbleweed
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed),
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # and curl for downloading/installing the GPG key
@@ -73,7 +76,9 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   yast2-users \
   yast2-xml \
   yast2-ycp-ui-bindings \
-  && zypper clean -a
+  && zypper clean -a \
+  && rm -rf /usr/lib*/ruby/gems/*/cache/ \
+  && rm -rf /usr/share/doc/
 
 COPY yast-travis-ruby /usr/local/bin/
 ENV LC_ALL=en_US.UTF-8

--- a/Dockerfile.sle12-sp2
+++ b/Dockerfile.sle12-sp2
@@ -4,6 +4,9 @@
 # for running the YaST tests.
 FROM opensuse:42.2
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
@@ -73,7 +76,9 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   yast2-users \
   yast2-xml \
   yast2-ycp-ui-bindings \
-  && zypper clean -a
+  && zypper clean -a \
+  && rm -rf /usr/lib*/ruby/gems/*/cache/ \
+  && rm -rf /usr/share/doc/
 
 COPY yast-travis-ruby /usr/local/bin/
 ENV LC_ALL=en_US.UTF-8

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -4,6 +4,9 @@
 # for running the YaST tests.
 FROM opensuse:42.3
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
@@ -73,7 +76,9 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   yast2-users \
   yast2-xml \
   yast2-ycp-ui-bindings \
-  && zypper clean -a
+  && zypper clean -a \
+  && rm -rf /usr/lib*/ruby/gems/*/cache/ \
+  && rm -rf /usr/share/doc/
 
 COPY yast-travis-ruby /usr/local/bin/
 ENV LC_ALL=en_US.UTF-8

--- a/Dockerfile.sle12-sp4
+++ b/Dockerfile.sle12-sp4
@@ -5,6 +5,9 @@
 # for running the YaST tests.
 FROM opensuse:42.3
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
@@ -74,7 +77,9 @@ RUN RUBY_VERSION=`rpm --eval '%{rb_default_ruby_abi}'` && \
   yast2-users \
   yast2-xml \
   yast2-ycp-ui-bindings \
-  && zypper clean -a
+  && zypper clean -a \
+  && rm -rf /usr/lib*/ruby/gems/*/cache/ \
+  && rm -rf /usr/share/doc/
 
 COPY yast-travis-ruby /usr/local/bin/
 ENV LC_ALL=en_US.UTF-8

--- a/Dockerfile.sle15
+++ b/Dockerfile.sle15
@@ -4,6 +4,9 @@
 # for running the YaST tests.
 FROM opensuse/leap:15.0
 
+# do not install the files marked as documentation (use "rpm --excludedocs")
+RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
+
 # we need to install Ruby first to define the %{rb_default_ruby_abi} RPM macro
 # and curl for downloading/installing the GPG key
 # see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run
@@ -75,7 +78,9 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   yast2-users \
   yast2-xml \
   yast2-ycp-ui-bindings \
-  && zypper clean -a
+  && zypper clean -a \
+  && rm -rf /usr/lib*/ruby/gems/*/cache/ \
+  && rm -rf /usr/share/doc/
 
 COPY yast-travis-ruby /usr/local/bin/
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
- Do not install the documentation
- Remove the Rubygem cache
- The final (unpacked) image is about 24MB smaller
- Travis should be a bit faster