### PR TITLE
Make the steps in yast-travis-ruby configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ The workflow is:
 - If the code needs additional packages install them using the `zypper install`
   command from the local `Dockerfile`. (If the package is need by more modules
   you can add it into the original Docker image.)
-- Run the `yast-travis-ruby` script.
+- Run the `yast-travis-ruby` script. (Optionally you can use the `-x` and `-o`
+  options to split the work into several smaller tasks and run them in parallel.)
 

--- a/yast-travis-ruby
+++ b/yast-travis-ruby
@@ -3,35 +3,242 @@
 # This is a CI build script for running inside the Travis builds.
 # It's designed for the YaST packages written in Ruby.
 
-# exit on error immediately, print the executed commands
-set -e -x
+# exit on error immediately
+set -e
 
-rake check:pot
+# all known steps in this script
+ALL_STEPS="pot, rubocop, spelling, yardoc, build, tests, package"
 
-if [ -e .rubocop.yml ]; then
-  rubocop
-fi;
-# if rubocop is not used then rake package latter run syntax check
+# when adding a new step
+# 1) add it to $ALL_STEPS
+# 2) handle it in disable_all(), set_defaults(), exclude(), run_only()
+#    and dump_settings()
+# 3) run it in the "main" part
 
-if [ -e .spell.yml ]; then
-  rake check:spelling
+function usage() {
+  echo "Usage: $0 [OPTIONS]"
+  echo
+  echo "OPTIONS:"
+  echo -e "\t -x <step> \t exclude the specified step"
+  echo -e "\t -o <step> \t run only the specified step"
+  echo -e "\t -y        \t run \"rake check:doc\" (more strict) in the \"yardoc\" step"
+  echo -e "\t -d        \t enable debug mode"
+  echo -e "\t -h        \t print this help"
+  echo
+  echo "The known steps are: $ALL_STEPS"
+  echo
+  echo "The script analyzes the configuration files and runs the checks accordingly."
+  echo "You can manually override the autodection using the -x or -o option."
+  echo
+  echo "Options -x and -o are exclusive and cannot be used together,"
+  echo "but they can be used repeatedly to specify several steps."
+}
+
+# disable all steps
+function disable_all() {
+  # run this only once
+  if [ "$DISABLE_ALL" != "1" ]; then
+    RUN_CHECK_POT=0
+    RUN_RUBOCOP=0
+    RUN_CHECK_SPELLING=0
+    RUN_CHECK_YARDOC=0
+    RUN_BUILD=0
+    RUN_TESTS=0
+    RUN_BUILD_PACKAGE=0
+
+    DISABLE_ALL=1
+  fi
+}
+
+# set defaults, run everything possible
+function set_defaults() {
+  RUN_CHECK_POT=1
+
+  if [ -e .rubocop.yml ]; then
+    RUN_RUBOCOP=1
+  else
+    RUN_RUBOCOP=0
+  fi;
+
+  if [ -e .spell.yml ]; then
+    RUN_CHECK_SPELLING=1
+  else
+    RUN_CHECK_SPELLING=0
+  fi
+
+  # run yardoc when there is at least one Ruby file
+  if [ ! -z `find . -name '*.rb' -print -quit` ]; then
+    RUN_CHECK_YARDOC=1
+  else
+    RUN_CHECK_YARDOC=0
+  fi
+
+  # we need to build only the autotools based packages
+  if [ -e Makefile.cvs ]; then
+    RUN_BUILD=1
+  else
+    RUN_BUILD=0
+  fi
+
+  RUN_TESTS=1
+  RUN_BUILD_PACKAGE=1
+}
+
+function exclude() {
+  if [ "$RUN_ONLY_USED" == "1" ]; then
+    echo "ERROR: Options -x -o are exclusive and cannot be used together!"
+    exit 1
+  fi
+
+  case $1 in
+    pot)
+      RUN_CHECK_POT=0
+      ;;
+    rubocop)
+      RUN_RUBOCOP=0
+      ;;
+    spelling)
+      RUN_CHECK_SPELLING=0
+      ;;
+    yardoc)
+      RUN_CHECK_YARDOC=0
+      ;;
+    build)
+      RUN_BUILD=0
+      ;;
+    tests)
+      RUN_TESTS=0
+      ;;
+    package)
+      RUN_BUILD_PACKAGE=0
+      ;;
+    *)
+      echo "ERROR: Unknown step: '$1'"
+      echo "Known steps: $ALL_STEPS"
+      exit 1
+  esac
+  EXCLUDE_USED=1
+}
+
+function run_only() {
+  if [ "$EXCLUDE_USED" == "1" ]; then
+    echo "ERROR: Options -x -o are exclusive and cannot be used together!"
+    exit 1
+  fi
+
+  # disable the other steps
+  disable_all
+
+  case $1 in
+    pot)
+      RUN_CHECK_POT=1
+      ;;
+    rubocop)
+      RUN_RUBOCOP=1
+      ;;
+    spelling)
+      RUN_CHECK_SPELLING=1
+      ;;
+    yardoc)
+      RUN_CHECK_YARDOC=1
+      ;;
+    build)
+      RUN_BUILD=1
+      ;;
+    tests)
+      RUN_TESTS=1
+      ;;
+    package)
+      RUN_BUILD_PACKAGE=1
+      ;;
+    *)
+      echo "ERROR: Unknown step: '$1'"
+      echo "Known steps: $ALL_STEPS"
+      exit 1
+  esac
+  RUN_ONLY_USED=1
+}
+
+function dump_settings() {
+  echo "Script configuration:"
+  echo "RUN_CHECK_POT: $RUN_CHECK_POT"
+  echo "RUN_RUBOCOP: $RUN_RUBOCOP"
+  echo "RUN_CHECK_SPELLING: $RUN_CHECK_SPELLING"
+  echo "RUN_CHECK_YARDOC: $RUN_CHECK_YARDOC"
+  echo "RUN_BUILD: $RUN_BUILD"
+  echo "RUN_TESTS: $RUN_TESTS"
+  echo "RUN_BUILD_PACKAGE: $RUN_BUILD_PACKAGE"
+  echo
+}
+
+# initializa the defaults and parse the command line options
+
+set_defaults
+
+while getopts ":x:o:dhy" arg; do
+  case $arg in
+    x)
+      exclude $OPTARG
+      ;;
+    o)
+      run_only $OPTARG
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    d)
+      DEBUG=1
+      ;;
+    y)
+      USE_RAKE_CHECK_YARDOC=1
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# start the main script
+
+# enable debug
+if [ "$DEBUG" == "1" ]; then
+  dump_settings
+  set -x
 fi
 
-# run yardoc when there is at least one Ruby file
-if [ ! -z `find . -name '*.rb' -print -quit` ]; then
-  yardoc
+[ "$RUN_CHECK_POT" == "1" ] && rake check:pot
+
+# if rubocop is not used then rake package later runs a syntax check at least
+[ "$RUN_RUBOCOP" == "1" ] && rubocop
+
+[ "$RUN_CHECK_SPELLING" == "1" ] && rake check:spelling
+
+if [ "$RUN_CHECK_YARDOC" == "1" ]; then
+  if [ "$USE_RAKE_CHECK_YARDOC" == "1" ]; then
+    rake check:doc
+  else
+    yardoc
+  fi
 fi
 
 # autotools based package
 if [ -e Makefile.cvs ]; then
-  make -f Makefile.cvs
-  make -s
-  make -s install
-  make -s check VERBOSE=1 Y2DIR=`pwd`
+  if [ "$RUN_BUILD" == "1" ]; then
+    make -f Makefile.cvs
+    make -s
+    make -s install
+  fi
+
+  [ "$RUN_TESTS" == "1" ] && make -s check VERBOSE=1 Y2DIR=`pwd`
 fi
 
 # enable coverage reports
-COVERAGE=1 CI=1 rake test:unit
+[ "$RUN_TESTS" == "1" ] && COVERAGE=1 CI=1 rake test:unit
+
+# the rest is a package build if it is disabled then just finish now
+[ "$RUN_BUILD_PACKAGE" == "0" ] && exit 0
 
 # run package with all its checks, but be silent as possible. STDOUT is sent to dev null due to output of tar command
 rake --silent package > /dev/null


### PR DESCRIPTION
The `yast-travis-ruby` script, which we use in Docker builds in Travis, is not configurable and does not allow to set which steps it should run and which not. Usually that's not a problem as there is some autodetection (e.g. if `.rubocop.yml` file exists then it runs `rubocop`).

However, in some cases you need to override this autodetection. With this improvement you can either disable some steps or run only the required steps.

Examples:

```shell
# exclude rubocop, run the other steps
./yast-travis-ruby -x rubocop
# run only unit tests, skip the rest
./yast-travis-ruby -o tests
```

The change is backward compatible, if you run just `./yast-travis-ruby` it will use the same defaults and run the same checks as in the past, no change required on the YaST side.

## Parallel Build at Travis

With this update you can easily split the Travis work into several parallel jobs. It does not make much sense for small packages, but for big packages like `yast2-storage-ng` it can really benefit from the parallel jobs.

Example `.travis.yml` file:

```yaml
env:
  # only the unit tests
  - CMD='yast-travis-ruby -o tests'
  # the rest
  - CMD='yast-travis-ruby -x tests'

script:
  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-test-image $CMD
```

See my PoC example for the parallel build in `yast2-storage-ng`: https://travis-ci.org/lslezak/yast-storage-ng/builds/383572188 (that includes some more optimizations like yardoc below and running tests in parallel).

## Yardoc

The script by default runs `yardoc`. But some packages additionally run `rake check:doc` which is more strict, but internally runs `yardoc` as well. That means some packages runs it twice. For small packages it's not a big issue, but for example in `yast2-storage-ng` it takes more than 90 seconds for each run.

So I have introduced a new `-y` option which runs `rake check:doc` instead of the default `yardoc` and avoids running it twice. (The extra `rake check:doc` call then needs to be removed manually).

# Notes

- I know it's not nice code, I'm not a good shell programmer... :worried: 
- If you really do not like it I'd drop it and rewrite to Ruby, but I'd rather avoid that, it's only a stupid CI script after all