### PR TITLE
Run Rubocop in parallel

### DIFF
--- a/yast-travis-ruby
+++ b/yast-travis-ruby
@@ -171,6 +171,16 @@ function dump_settings() {
   echo
 }
 
+# run parallel rubocop if it is available,
+# otherwise fallback to standard rubocop call
+function run_rubocop() {
+  if rake -T | grep -q "^rake check:rubocop"; then
+    rake check:rubocop
+  else
+    rubocop
+  fi
+}
+
 # initializa the defaults and parse the command line options
 
 set_defaults
@@ -211,7 +221,7 @@ fi
 [ "$RUN_CHECK_POT" == "1" ] && rake check:pot
 
 # if rubocop is not used then rake package later runs a syntax check at least
-[ "$RUN_RUBOCOP" == "1" ] && rubocop
+[ "$RUN_RUBOCOP" == "1" ] && run_rubocop
 
 [ "$RUN_CHECK_SPELLING" == "1" ] && rake check:spelling
 


### PR DESCRIPTION
- This speeds up the Rubocop check at Travis about +50% (there is ~1.5 CPU power available).
- See https://github.com/yast/yast-rake/pull/57 for more details
- We need to check the `rake -T` output if the task is available, if not then run the Rubocop the old way so it works also in the older SLE12 docker images.