### PR TITLE
Install ShellCheck, apply it on the Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ services:
   - docker
 
 script:
-  # at least run a syntax check for the Travis script
-  - bash -n yast-travis-ruby
   # build the Docker image
   - docker build -t yast-test-image -f Dockerfile.$DOCKER_TAG .
+  # check the Travis script
+  - 'if [ "$DOCKER_TAG" = "latest" ]; then docker run -it yast-test-image shellcheck /usr/local/bin/yast-travis-ruby; fi'
 
 env:
   # define the build matrix to build all images in parallel

--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -16,7 +16,8 @@ RUN zypper --non-interactive dup --no-recommends && \
 # import the YaST OBS GPG key
 RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
 
-RUN zypper ar -f https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
+# Prefer the packages from the YaST:Head repository
+RUN zypper ar -p 50 -f https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Tumbleweed/ yast
 
 RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   zypper --non-interactive in --no-recommends \
@@ -47,6 +48,7 @@ RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   build \
   obs-service-source_validator \
   patterns-rpm-macros \
+  ShellCheck \
   yast2 \
   yast2-add-on \
   yast2-bootloader \

--- a/yast-travis-ruby
+++ b/yast-travis-ruby
@@ -19,11 +19,11 @@ function usage() {
   echo "Usage: $0 [OPTIONS]"
   echo
   echo "OPTIONS:"
-  echo -e "\t -x <step> \t exclude the specified step"
-  echo -e "\t -o <step> \t run only the specified step"
-  echo -e "\t -y        \t run \"rake check:doc\" (more strict) in the \"yardoc\" step"
-  echo -e "\t -d        \t enable debug mode"
-  echo -e "\t -h        \t print this help"
+  echo -e "\\t -x <step> \\t exclude the specified step"
+  echo -e "\\t -o <step> \\t run only the specified step"
+  echo -e "\\t -y        \\t run \"rake check:doc\" (more strict) in the \"yardoc\" step"
+  echo -e "\\t -d        \\t enable debug mode"
+  echo -e "\\t -h        \\t print this help"
   echo
   echo "The known steps are: $ALL_STEPS"
   echo
@@ -67,7 +67,7 @@ function set_defaults() {
   fi
 
   # run yardoc when there is at least one Ruby file
-  if [ ! -z `find . -name '*.rb' -print -quit` ]; then
+  if [ -n "$(find . -name '*.rb' -print -quit)" ]; then
     RUN_CHECK_YARDOC=1
   else
     RUN_CHECK_YARDOC=0
@@ -188,10 +188,10 @@ set_defaults
 while getopts ":x:o:dhy" arg; do
   case $arg in
     x)
-      exclude $OPTARG
+      exclude "$OPTARG"
       ;;
     o)
-      run_only $OPTARG
+      run_only "$OPTARG"
       ;;
     h)
       usage
@@ -241,7 +241,7 @@ if [ -e Makefile.cvs ]; then
     make -s install
   fi
 
-  [ "$RUN_TESTS" == "1" ] && make -s check VERBOSE=1 Y2DIR=`pwd`
+  [ "$RUN_TESTS" == "1" ] && make -s check VERBOSE=1 Y2DIR="$(pwd)"
 fi
 
 # enable coverage reports
@@ -279,4 +279,5 @@ rpmbuild -bb --nocheck package/*.spec || rpmbuild -bb --nocheck --nodeps package
 rpm -iv --force --nodeps $PKG_DIR/RPMS/*/*.rpm
 rpm -Uv --force --nodeps $PKG_DIR/RPMS/*/*.rpm
 # get the plain package names and remove all packages at once
-rpm -ev --nodeps `rpm -q --qf '%{NAME} ' -p $PKG_DIR/RPMS/*/*.rpm`
+mapfile -t packages < <(rpm -q --qf '%{NAME} ' -p $PKG_DIR/RPMS/*/*.rpm)
+rpm -ev --nodeps "${packages[@]}"


### PR DESCRIPTION
- Install shellcheck package
- Prefer the YaST:Head repository (so if the shellcheck is upgraded in Tumbleweed later we still install the version from YaST:Head)
  - There is the same problem as with Rubocop - new version might fail with the code which was considered correct in the past, resulting in false failures
  - I have copied the latest version from TW to [YaST:Head/ShellCheck](https://build.opensuse.org/package/show/YaST:Head/ShellCheck), this is a newer version than in Leap 15.0
- Adapted the `yast-travis-ruby` script to pass the shellcheck tests
  - Fixing [SC2046](https://github.com/koalaman/shellcheck/wiki/SC2046) and [SC2207](https://github.com/koalaman/shellcheck/wiki/SC2207) on the very last line was a bit tricky to me...
- Check the file at Travis as well