### PR TITLE
Added BRP packages to be more compatible with "osc build"

### DIFF
--- a/Dockerfile.latest
+++ b/Dockerfile.latest
@@ -21,6 +21,8 @@ RUN zypper ar -p 50 -f https://download.opensuse.org/repositories/YaST:/Head/ope
 
 RUN RUBY_VERSION=ruby:`rpm --eval '%{rb_ver}'` && \
   zypper --non-interactive in --no-recommends \
+  brp-check-suse \
+  brp-extract-appdata \
   aspell-en \
   fdupes \
   git \


### PR DESCRIPTION
OSC additionally installs the `brp-check-suse` and `brp-extract-appdata` packages into the build root (BRP = build root policy).

These packages contain additional scripts which scan the package for common mistakes. Without them it could happen that a Travis build passed but later, after merging the change, the Jenkins build failed because of some problem reported by the additional checks.

The `brp-check-suse` package contains the extra checks, the `brp-extract-appdata` package is probably not needed for YaST, but let's install it as well to be more compatible with OSC. (The package contains just a tiny script, it won't hurt.)

### Example

For example this issue was not found in Travis, only later by Jenkins:

```
ERROR: No sufficient Category definition: /usr/src/packages/BUILDROOT/yast2-installation-4.1.30-0.x86_64//usr/share/applications/YaST2/installation.desktop 
Please refer to https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories
WARNING: Empty GenericName: /usr/src/packages/BUILDROOT/yast2-installation-4.1.30-0.x86_64//usr/share/applications/YaST2/installation.desktop
ERROR: No sufficient Category definition: /usr/src/packages/BUILDROOT/yast2-installation-4.1.30-0.x86_64//usr/share/applications/YaST2/upgrade.desktop 
Please refer to https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories
WARNING: Empty GenericName: /usr/src/packages/BUILDROOT/yast2-installation-4.1.30-0.x86_64//usr/share/applications/YaST2/upgrade.desktop
Errors in installed desktop file detected. Please refer to http://en.opensuse.org/SUSE_Package_Conventions/RPM_Macros
```

BTW the additional check scripts are:

/usr/lib/rpm/brp-suse.d/brp-05-permissions
/usr/lib/rpm/brp-suse.d/brp-15-strip-debug
/usr/lib/rpm/brp-suse.d/brp-25-symlink
/usr/lib/rpm/brp-suse.d/brp-30-desktop
/usr/lib/rpm/brp-suse.d/brp-35-rpath
/usr/lib/rpm/brp-suse.d/brp-40-rootfs
/usr/lib/rpm/brp-suse.d/brp-45-tcl
/usr/lib/rpm/brp-suse.d/brp-50-check-python
/usr/lib/rpm/brp-suse.d/brp-55-boot-scripts
/usr/lib/rpm/brp-suse.d/brp-60-hook
/usr/lib/rpm/brp-suse.d/brp-65-lib64-linux