### PR TITLE
The openSUSE 42.3 image has been moved

### DIFF
--- a/Dockerfile.sle12-sp2
+++ b/Dockerfile.sle12-sp2
@@ -1,8 +1,8 @@
 # SLE12-SP2 is officially not available at the Docker Hub
-# because of some licensing issues, use openSUSE-42.2 as a replacement.
+# because of some licensing issues, use openSUSE-42.3 as a replacement.
 # It shares the same core packages and should be close enough to SLE12-SP2
 # for running the YaST tests.
-FROM opensuse:42.2
+FROM opensuse/leap:42.3
 
 # do not install the files marked as documentation (use "rpm --excludedocs")
 RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf
@@ -18,7 +18,7 @@ RUN zypper --non-interactive in --no-recommends curl ruby && zypper clean -a
 RUN rpm --import https://build.opensuse.org/projects/YaST/public_key
 
 # Set a higher priority for the yast_sle_12_sp2 repo to prefer the packages from
-# this repo even if they have a lower version than the original 42.2 packages.
+# this repo even if they have a lower version than the original 42.3 packages.
 RUN zypper ar -f -p 95 https://download.opensuse.org/repositories/YaST:/SLE-12:/SP2/SLE_12_SP2/ \
 yast_sle12_sp2
 

--- a/Dockerfile.sle12-sp3
+++ b/Dockerfile.sle12-sp3
@@ -2,7 +2,7 @@
 # because of some licensing issues, use openSUSE-42.3 as a replacement.
 # It shares the same core packages and should be close enough to SLE12-SP3
 # for running the YaST tests.
-FROM opensuse:42.3
+FROM opensuse/leap:42.3
 
 # do not install the files marked as documentation (use "rpm --excludedocs")
 RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf

--- a/Dockerfile.sle12-sp4
+++ b/Dockerfile.sle12-sp4
@@ -3,7 +3,7 @@
 # as there is no openSUSE-42.4 release which would be the equivalent to SLES12-SP4.
 # It shares the same core packages and should be close enough to SLE12-SP4
 # for running the YaST tests.
-FROM opensuse:42.3
+FROM opensuse/leap:42.3
 
 # do not install the files marked as documentation (use "rpm --excludedocs")
 RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf

--- a/Dockerfile.sle12-sp5
+++ b/Dockerfile.sle12-sp5
@@ -3,7 +3,7 @@
 # as there is no openSUSE-42.5 release which would be the equivalent to SLES12-SP5.
 # It shares the same core packages and should be close enough to SLE12-SP5
 # for running the YaST tests.
-FROM opensuse:42.3
+FROM opensuse/leap:42.3
 
 # do not install the files marked as documentation (use "rpm --excludedocs")
 RUN sed -i -e "s/^.*rpm.install.excludedocs.*/rpm.install.excludedocs = yes/" /etc/zypp/zypp.conf


### PR DESCRIPTION
- The image has been moved from `opensuse:42.3` to `opensuse/leap:42.3`
- See https://hub.docker.com/r/opensuse/leap/tags
